### PR TITLE
Add support for specifying resource pool, VM host, or vApp when deploying a VM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.0
+    * Add support for deploying VMs into a resource pool, directly to a VM host, order to a vApp.
+    * Fix bug with testing IP connectivity prior to creating a VM, when that VM has multiple NICs defined.
+
 ## 1.1.14
     * Fix bug in evaluating Chef provisioner attributes
     * If VM has more than one IP address as reported by VM tools, ping each one and return the first IP that responds.

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_CreateVM.ps1
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_CreateVM.ps1
@@ -134,11 +134,12 @@ function _CreateVM {
 
         # Verify any IP addresses defined in configuration are not already in use
         # and resolve network portgroups
-        $netConfigs = @(ConvertFrom-Json -InputObject $NICSpec)
+        $netConfigs = $NICSpec | ConvertFrom-Json
         foreach ($netConfig in $netConfigs) {
-
+            
             # Verify the IP address(s) that we're about to set are not already in use
-            if ($netConfig.IPAddress) {
+            if ($netConfig.IPAddress) {                
+                Write-Debug -Message "Pinging $($netConfig.IPAddress)"                
                 $pingable = Test-Connection -ComputerName $netConfig.IPAddress -Count 2 -Quiet
                 if ($pingable) {
                     Write-Error -Message "$($netConfig.IPAddress) appears to already be in use."

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_CreateVM.ps1
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_CreateVM.ps1
@@ -9,7 +9,7 @@ function _CreateVM {
         [ValidateNotNullOrEmpty()]
         [string]$VMTemplate,
 
-        [Parameter(Mandatory, ParameterSet ='cluster')]
+        [Parameter(Mandatory, ParameterSetName ='cluster')]
         [ValidateNotNullOrEmpty()]
         [string]$Cluster,
         

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_CreateVM.ps1
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_CreateVM.ps1
@@ -1,5 +1,5 @@
 function _CreateVM {
-    [cmdletbinding()]
+    [cmdletbinding(DefaultParameterSetName='cluster')]
     param (
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
@@ -9,9 +9,21 @@ function _CreateVM {
         [ValidateNotNullOrEmpty()]
         [string]$VMTemplate,
 
-        [Parameter(Mandatory)]
+        [Parameter(Mandatory, ParameterSet ='cluster')]
         [ValidateNotNullOrEmpty()]
         [string]$Cluster,
+        
+        [Parameter(Mandatory, ParameterSetName = 'resourcepool')]
+        [ValidateNotNullOrEmpty()]
+        [string]$ResourcePool,
+        
+        [Parameter(Mandatory, ParameterSetName = 'vmhost')]
+        [ValidateNotNullOrEmpty()]
+        [string]$VMHost,
+        
+        [Parameter(Mandatory, ParameterSetName = 'vapp')]
+        [ValidateNotNullOrEmpty()]
+        [string]$vApp,
 
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
@@ -50,20 +62,49 @@ function _CreateVM {
             Write-Error -Message "Unable to resolve template $VMTemplate"
             $continue = $false
         }
-
-        # Resolve cluster
-        $clus = Get-Cluster -Name $Cluster -verbose:$false -ErrorAction SilentlyContinue | Select-Object -First 1
-        if ($clus -ne $null) { 
-            Write-Debug -Message "Cluster: $($clus.Name)"
-        } else {
-            $clus = Get-VMHost -Name $Cluster -Verbose:$false -ErrorAction SilentlyContinue | Select-Object -First 1
-            if ($null -ne $clus) {
-                Write-Debug -Message "VMHost: $($clus.Name)"
-            } else {
-                Write-Error -Message "Unable to resolve cluster or VM Host [$Cluster]"
-                $continue = $false
+        
+        switch ($PSCmdlet.ParameterSetName) {
+            'cluster' {
+                # Resolve cluster
+                $viContainer = Get-Cluster -Name $Cluster -Verbose:$false -ErrorAction SilentlyContinue | Select-Object -First 1
+                if ($viContainer -ne $null) { 
+                    Write-Debug -Message "Cluster: $($viContainer.Name)"
+                } else {
+                    Write-Error -Message "Unable to resolve cluster [$Cluster]"
+                    $continue = $false
+                }
             }
-        }
+            'vmhost' {
+                # Resolve VM host
+                $viContainer = Get-VMHost -Name $VMHost -Verbose:$false -ErrorAction SilentlyContinue | Select-Object -First 1
+                if ($null -ne $viContainer) {
+                    Write-Debug -Message "VMHost: $($viContainer.Name)"
+                } else {
+                    Write-Error -Message "Unable to resolve VM host [$VMHost]"
+                    $continue = $false
+                }
+            }
+            'resourcepool' {
+                # Resolve VM host
+                $viContainer = Get-ResourcePool -Name $ResourcePool -Verbose:$false -ErrorAction SilentlyContinue | Select-Object -First 1
+                if ($null -ne $viContainer) {
+                    Write-Debug -Message "Resource Pool: $($viContainer.Name)"
+                } else {
+                    Write-Error -Message "Unable to resolve resource pool [$ResourcePool]"
+                    $continue = $false
+                }
+            }
+            'vapp' {
+                # Resolve vApp
+                $viContainer = Get-VApp -Name $vApp -Verbose:$false -ErrorAction SilentlyContinue | Select-Object -First 1
+                if ($null -ne $viContainer) {
+                    Write-Debug -Message "vApp: $($viContainer.Name)"
+                } else {
+                    Write-Error -Message "Unable to resolve vApp [$vApp]"
+                    $continue = $false
+                }
+            }
+        }        
 
         # Resolve datastore / datastore cluster
         $datastore = Get-Datastore -Name $InitialDatastore -verbose:$false -ErrorAction SilentlyContinue | Select-Object -First 1
@@ -153,7 +194,7 @@ function _CreateVM {
                 Template = $template
                 Datastore = $datastore
                 #DiskStorageFormat = $diskFormat
-                ResourcePool = $clus
+                ResourcePool = $viContainer
                 RunAsync = $true
                 Verbose = $false
                 Confirm = $false

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_CreateVM.ps1
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_CreateVM.ps1
@@ -104,7 +104,7 @@ function _CreateVM {
                     $continue = $false
                 }
             }
-        }        
+        }
 
         # Resolve datastore / datastore cluster
         $datastore = Get-Datastore -Name $InitialDatastore -verbose:$false -ErrorAction SilentlyContinue | Select-Object -First 1

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_SetVMNICs.ps1
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_SetVMNICs.ps1
@@ -20,7 +20,7 @@ function _SetVMNICs {
     $success = $false
     $specClone = $null
                     
-    $netConfigs = @(ConvertFrom-Json -InputObject $NICSpec)
+    $netConfigs = $NICSpec | ConvertFrom-Json
     Write-Debug "Configuration NIC count: $($netConfigs.count)"
 
     $vmNICs = @($vm | Get-NetworkAdapter -Verbose:$false -Debug:$false)

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_SetVMNICs.ps1
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_SetVMNICs.ps1
@@ -125,10 +125,17 @@ function _SetVMNICs {
                             IpMode = 'UseStaticIp'
                             IpAddress = $netConfig.IPAddress
                             SubnetMask = $netConfig.SubnetMask
-                            DefaultGateway = $netConfig.DefaultGateway
-                            Dns = $netConfig.DNSServers
+                            #DefaultGateway = $netConfig.DefaultGateway
+                            #Dns = $netConfig.DNSServers
                             Verbose = $false
                         }
+                        if ($netConfig.DefaultGateway) {
+                            $params.DefaultGateway = $netConfig.DefaultGateway
+                        }
+                        if ($netConfig.DNSServers) {
+                            $params.Dns = $netConfig.DNSServers
+                        }                        
+                        
                         if ($vmNIC -ne $null) {
                             $params.NetworkAdapterMac = $vmNic.MacAddress
                         }

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Invoke.ps1
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Invoke.ps1
@@ -41,6 +41,9 @@ switch ($type) {
                 vRAM = $Options.options.vRAM
                 Datacenter = $Options.options.Datacenter
                 Cluster = $Options.options.Cluster
+                ResourcePool = $Options.options.ResourcePool
+                VMHost = $Options.options.VMHost
+                vApp = $Options.options.vApp
                 VMFolder = $Options.options.VMFolder
                 InitialDatastore = $Options.options.InitialDatastore
                 Disks = ConvertTo-Json -InputObject $Options.options.disks -Depth 100
@@ -165,6 +168,9 @@ switch ($type) {
                     vRAM = $ResourceOptions.options.vRAM
                     Datacenter = $ResourceOptions.options.Datacenter
                     Cluster = $ResourceOptions.options.Cluster
+                    VMHost = $ResourceOptions.options.VMHost
+                    ResourcePool = $ResourceOptions.options.ResourcePool
+                    vApp = $ResourceOptions.options.vApp
                     VMFolder = $ResourceOptions.options.VMFolder
                     InitialDatastore = $ResourceOptions.options.InitialDatastore
                     Disks = ConvertTo-Json -InputObject $ResourceOptions.options.disks

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/POSHOrigin_vSphere_VM.schema.mof
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/POSHOrigin_vSphere_VM.schema.mof
@@ -22,5 +22,8 @@ class POSHOrigin_vSphere_VM : OMI_BaseResource
     [Write] String Datacenter;
     [Write] String InitialDatastore;
     [Write] String Cluster;
+    [Write] String ResourcePool;
+    [Write] String VMHost;
+    [Write] String vApp;
     [Write] String Provisioners;
 };

--- a/POSHOrigin_vSphere/POSHOrigin_vSphere.psd1
+++ b/POSHOrigin_vSphere/POSHOrigin_vSphere.psd1
@@ -1,6 +1,6 @@
 @{
 RootModule = 'POSHOrigin_vSphere.psm1'
-ModuleVersion = '1.1.14'
+ModuleVersion = '1.2.0'
 GUID = 'af4099cf-30a1-44eb-8c74-a10948245227'
 Author = 'Brandon Olin'
 Copyright = '(c) 2016 Brandon Olin. All rights reserved.'
@@ -14,7 +14,9 @@ PrivateData = @{
         LicenseUri = 'http://www.apache.org/licenses/LICENSE-2.0'
         ProjectUri = 'https://github.com/devblackops/POSHOrigin_vSphere'
         #IconUri = ''
-        ReleaseNotes = ''
+        ReleaseNotes = "
+- Add support for deploying VMs into a resource pool, directly to a VM host, order to a vApp.
+- Fix bug with testing IP connectivity prior to creating a VM, when that VM has multiple NICs defined."
         # External dependent modules of this module
         # ExternalModuleDependencies = ''
     }


### PR DESCRIPTION
Previously it was only possible to deploy a VM into a named cluster. This PR adds support for deploying into the below containers as well:
- resource pool
- VM host
- vApp

The options below are valid DSC properties for VM deployment location. 

> **ONLY ONE CAN BE USED PER VM CONFIGURATION**. 
> Using more than one option will produce a runtime error.
- Cluster
- ResourcePool
- VMHost
- vApp

VMware supports having more than one resource pool or vApp with the same name. **This PR only includes support for unique names. When searching for a resource pool or vApp by name, the first match will be used**.
