### PR TITLE
Add tag support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Unreleased
+    * Add support for managing tags on VMs.
+
 ## 1.2.0
     * Add support for deploying VMs into a resource pool, directly to a VM host, order to a vApp.
     * Fix bug with testing IP connectivity prior to creating a VM, when that VM has multiple NICs defined.

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_SetTags.ps1
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_SetTags.ps1
@@ -40,10 +40,10 @@ function _SetTags {
     
     # Remove any tag assignments in vCenter that are NOT in the desired tag list
     foreach ($tagAssignment in $tagAssignments) {
-        $match = $desiredTags | Where-Object {($_.Category -eq $tagAssistnment.Tag.Category.Name) -and ($_.Name -eq $tagAssistnment.Tag.Name)}
+        $match = $desiredTags | Where-Object {($_.Category -eq $tagAssignment.Tag.Category.Name) -and ($_.Name -eq $tagAssignment.Tag.Name)}
         if (-not $match ) {
             # Remove tag assignment in vCenter
-            Write-Verbose -Message "Remove tag [$($tagAssignment.Tag.Category.Name)/]"
+            Write-Verbose -Message "Remove tag [$($tagAssignment.Tag.Category.Name)/$(tagAssignment.Tag.Name)]"
             $tagAssignment | Remove-TagAssignment -Verbose:$false
         }
     }

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_SetTags.ps1
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_SetTags.ps1
@@ -1,0 +1,50 @@
+function _SetTags {
+    [cmdletbinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNull()]
+        $vm,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNull()]
+        [string]$Tags
+    )
+    
+    $desiredTags = $Tags | ConvertFrom-Json
+    $tagAssignments = $vm | Get-TagAssignment -Verbose:$false
+    $tagCategories = Get-TagCategory -Verbose:$false
+    $vCenterTags = Get-Tag -Verbose:$false 
+    
+    # Verify that each desired tag in configuration is applied in vCenter
+    # Apply if necessary
+    foreach ($desiredTag in $desiredTags) {
+        $match = $tagAssignments | Where-Object {($_.Tag.Category.Name -eq $desiredTag.Category) -and ($_.Tag.Name -eq $desiredTag.Name)}
+        if (-not $match) {
+            
+            # Validate the desired tag category is valid in vCenter
+            $tagCategory = $tagCategories | where Name -eq $desiredTag.Category                
+            if ($tagCategory) {
+                # Do we already have a tag for this?
+                $tag = $vCenterTags | Where-Object {$_.Name -eq $desiredTag.Name -and $_.Category.Name -eq $desiredTag.Category}
+                if ($null -eq $tag) {
+                    # Create tag
+                    $tag = New-Tag -Name $desiredTag.Name -Category $tagCategory -Verbose:$false
+                }
+                Write-Verbose -Message "Assigning tag [$($desiredTag.Category)/$($desiredTag.Name)]"
+                $vm | New-TagAssignment -Tag $tag -Verbose:$false 
+            } else {
+                Write-Error -Message "Unable to find tag category [$($desiredTag.Category)] in vCenter"
+            }
+        }
+    }
+    
+    # Remove any tag assignments in vCenter that are NOT in the desired tag list
+    foreach ($tagAssignment in $tagAssignments) {
+        $match = $desiredTags | Where-Object {($_.Category -eq $tagAssistnment.Tag.Category.Name) -and ($_.Name -eq $tagAssistnment.Tag.Name)}
+        if (-not $match ) {
+            # Remove tag assignment in vCenter
+            Write-Verbose -Message "Remove tag [$($tagAssignment.Tag.Category.Name)/]"
+            $tagAssignment | Remove-TagAssignment -Verbose:$false
+        }
+    }
+}

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_SetTags.ps1
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_SetTags.ps1
@@ -13,7 +13,7 @@ function _SetTags {
     $desiredTags = $Tags | ConvertFrom-Json
     $tagAssignments = $vm | Get-TagAssignment -Verbose:$false
     $tagCategories = Get-TagCategory -Verbose:$false
-    $vCenterTags = Get-Tag -Verbose:$false 
+    $vCenterTags = $tagCategories | Get-Tag -Verbose:$false 
     
     # Verify that each desired tag in configuration is applied in vCenter
     # Apply if necessary

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_SetTags.ps1
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_SetTags.ps1
@@ -15,8 +15,7 @@ function _SetTags {
     $tagCategories = Get-TagCategory -Verbose:$false
     $vCenterTags = $tagCategories | Get-Tag -Verbose:$false 
     
-    # Verify that each desired tag in configuration is applied in vCenter
-    # Apply if necessary
+    # Verify that each desired tag in configuration is applied in vCenter. Apply if necessary
     foreach ($desiredTag in $desiredTags) {
         $match = $tagAssignments | Where-Object {($_.Tag.Category.Name -eq $desiredTag.Category) -and ($_.Tag.Name -eq $desiredTag.Name)}
         if (-not $match) {
@@ -28,6 +27,7 @@ function _SetTags {
                 $tag = $vCenterTags | Where-Object {$_.Name -eq $desiredTag.Name -and $_.Category.Name -eq $desiredTag.Category}
                 if ($null -eq $tag) {
                     # Create tag
+                    Write-Verbose "Creating tag [$($desiredTag.Category)/$($desiredTag.Name)]"
                     $tag = New-Tag -Name $desiredTag.Name -Category $tagCategory -Verbose:$false
                 }
                 Write-Verbose -Message "Assigning tag [$($desiredTag.Category)/$($desiredTag.Name)]"
@@ -43,7 +43,7 @@ function _SetTags {
         $match = $desiredTags | Where-Object {($_.Category -eq $tagAssignment.Tag.Category.Name) -and ($_.Name -eq $tagAssignment.Tag.Name)}
         if (-not $match ) {
             # Remove tag assignment in vCenter
-            Write-Verbose -Message "Remove tag [$($tagAssignment.Tag.Category.Name)/$(tagAssignment.Tag.Name)]"
+            Write-Verbose -Message "Removing tag [$($tagAssignment.Tag.Category.Name)/$($tagAssignment.Tag.Name)]"
             $tagAssignment | Remove-TagAssignment -Verbose:$false
         }
     }

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_testTags.ps1
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_testTags.ps1
@@ -1,0 +1,37 @@
+function _TestTags {
+    [cmdletbinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNull()]
+        $vm,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNull()]
+        [string]$Tags
+    )
+
+    $result = $true
+
+    # Get tag information from vCenter
+    $desiredTags = $Tags | ConvertFrom-Json
+    $tagAssignments = $vm | Get-TagAssignment -Verbose:$false
+        
+    # Verify that each desired tag in configuration is applied in vCenter
+    # Apply if necessary
+    foreach ($desiredTag in $desiredTags) {
+        $match = $tagAssignments | Where-Object {($_.Tag.Category.Name -eq $desiredTag.Category) -and ($_.Tag.Name -eq $desiredTag.Name)}
+        if (-not $match) {
+            $result = $false
+        }
+    }
+    
+    # Remove any tag assignments in vCenter that are NOT in the desired tag list
+    foreach ($tagAssignment in $tagAssignments) {
+        $match = $desiredTags | Where-Object {($_.Category -eq $tagAssistnment.Tag.Category.Name) -and ($_.Name -eq $tagAssistnment.Tag.Name)}
+        if (-not $match ) {
+            $result = $false
+        }
+    }
+
+    return $result
+}

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_testTags.ps1
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_testTags.ps1
@@ -16,19 +16,20 @@ function _TestTags {
     $desiredTags = $Tags | ConvertFrom-Json
     $tagAssignments = $vm | Get-TagAssignment -Verbose:$false
         
-    # Verify that each desired tag in configuration is applied in vCenter
-    # Apply if necessary
+    # Verify that each desired tag in configuration is applied in vCenter. Apply if necessary
     foreach ($desiredTag in $desiredTags) {
         $match = $tagAssignments | Where-Object {($_.Tag.Category.Name -eq $desiredTag.Category) -and ($_.Tag.Name -eq $desiredTag.Name)}
         if (-not $match) {
+            Write-Verbose -Message "Tag [$($desiredTag.Category)/$($desiredTag.Name)] not set"
             $result = $false
         }
     }
     
     # Remove any tag assignments in vCenter that are NOT in the desired tag list
     foreach ($tagAssignment in $tagAssignments) {
-        $match = $desiredTags | Where-Object {($_.Category -eq $tagAssistnment.Tag.Category.Name) -and ($_.Name -eq $tagAssistnment.Tag.Name)}
+        $match = $desiredTags | Where-Object {($_.Category -eq $tagAssignment.Tag.Category.Name) -and ($_.Name -eq $tagAssignment.Tag.Name)}
         if (-not $match ) {
+            Write-Verbose -Message "Tag [$($tagAssignment.Tag.Category.Name)/$($tagAssignment.Tag.Name)] should be removed"
             $result = $false
         }
     }

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Invoke.ps1
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Invoke.ps1
@@ -42,6 +42,7 @@ switch ($type) {
                 Datacenter = $Options.options.Datacenter
                 Cluster = $Options.options.Cluster
                 VMFolder = $Options.options.VMFolder
+                Tags = $Options.options.Tags
                 InitialDatastore = $Options.options.InitialDatastore
                 Disks = ConvertTo-Json -InputObject $Options.options.disks -Depth 100
                 CustomizationSpec = $Options.options.CustomizationSpec
@@ -166,6 +167,7 @@ switch ($type) {
                     Datacenter = $ResourceOptions.options.Datacenter
                     Cluster = $ResourceOptions.options.Cluster
                     VMFolder = $ResourceOptions.options.VMFolder
+                    Tags = ConvertTo-Json -InputObject $ResourceOptions.options.Tags
                     InitialDatastore = $ResourceOptions.options.InitialDatastore
                     Disks = ConvertTo-Json -InputObject $ResourceOptions.options.disks
                     CustomizationSpec = $ResourceOptions.options.CustomizationSpec

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/POSHOrigin_vSphere_VM.psm1
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/POSHOrigin_vSphere_VM.psm1
@@ -48,6 +48,9 @@ function Get-TargetResource {
 
         [System.String]
         $CustomizationSpec,
+        
+        [System.String]
+        $Tags,
 
         [System.Management.Automation.PSCredential]
         $GuestCredentials,
@@ -143,6 +146,9 @@ function Set-TargetResource {
 
         [System.String]
         $CustomizationSpec,
+        
+        [System.String]
+        $Tags,
 
         [System.Management.Automation.PSCredential]
         $GuestCredentials,
@@ -386,6 +392,9 @@ function Test-TargetResource {
 
         [System.String]
         $CustomizationSpec,
+        
+        [System.String]
+        $Tags,
 
         [System.Management.Automation.PSCredential]
         $GuestCredentials,
@@ -487,6 +496,11 @@ function Test-TargetResource {
     $powerResult = _TestVMPowerState -vm $vm -PowerOnAfterCreation $PowerOnAfterCreation
     $match = if ( $powerResult) { 'MATCH' } else { 'MISMATCH' }
     Write-Verbose -Message "Power state: $match"
+
+    # Tags
+    if ($PSBoundParameters.ContainsKey('Tags')) {                
+        Write-Verbose ($Tags)        
+    }
 
     #endregion
 

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/POSHOrigin_vSphere_VM.psm1
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/POSHOrigin_vSphere_VM.psm1
@@ -594,7 +594,7 @@ function Test-TargetResource {
 
     _DisconnectFromvCenter -vCenter $vCenter
     
-    if (-not ($ramResult -and $cpuResult -and $vmDiskResult -and $guestDiskResult -and $powerResult -and $folderResult)) {
+    if (-not ($ramResult -and $cpuResult -and $vmDiskResult -and $guestDiskResult -and $powerResult -and $folderResult -and $tagResult)) {
         Write-Debug -Message "One or more tests failed"
         return $false
     }

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/POSHOrigin_vSphere_VM.schema.mof
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/POSHOrigin_vSphere_VM.schema.mof
@@ -14,6 +14,7 @@ class POSHOrigin_vSphere_VM : OMI_BaseResource
     [Write] String VMTemplate;
     [Write] String VMFolder;
     [Write] String CustomizationSpec;
+    [Write] String Tags;
     [Write, EmbeddedInstance("MSFT_Credential")] String GuestCredentials;
     [Write, EmbeddedInstance("MSFT_Credential")] String IPAMCredentials;
     [Write, EmbeddedInstance("MSFT_Credential")] String DomainJoinCredentials;


### PR DESCRIPTION
This adds the ability to manage tags assigned to VMs.
### Example

``` powershell
resource 'vsphere:vm' 'myvm01' @{
    # other options omitted for brevity
    tags = @(
        @{ category = 'Application'; Name = 'My Awesome App' }
        @{ category = 'Environment'; Name = 'Prod' }
        @{ category = 'BU'; Name = 'Engineering' }
        @{ category = 'BU'; Name = 'Sales' }
    )
}
```

A couple of points:
1. The tag categories must already be defined in vCenter. The DSC resource **WILL NOT** create them. This is because the vCenter admin can setup category properties such as multiplicity and scope that they probably don't want the DSC resource to be messing with.
2. The DSC resource **WILL** create the tags provided the category exists.
3. The DSC resource will remove the tag associations from the VM when they are not in the DSC configuration but the tags themselves **WILL NOT** be removed because the tags may be assigned to other objects in vCenter.
