### PR TITLE
Add support for updating / installing VM tools on a VM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
     * Add support for managing tags on VMs.
+    * Add support for installing/updating VM tools if out of date or not installed.
 
 ## 1.2.0
     * Add support for deploying VMs into a resource pool, directly to a VM host, order to a vApp.

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_TestVMTools.ps1
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_TestVMTools.ps1
@@ -1,0 +1,15 @@
+function _TestVMTools {
+    [cmdletbinding()]
+    param(
+        $VM
+    )
+    
+    # Possible values indicating tools need to be installed/updated
+    $old = @('guestToolsNeedUpgrade', 'guestToolsNotInstalled')
+    
+    if ($VM.ExtensionData.Guest.ToolsVersionStatus -notin $old) {
+        return $true
+    } else {
+        return $false
+    }
+}

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_UpdateTools.ps1
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_UpdateTools.ps1
@@ -1,0 +1,16 @@
+function _UpdateTools {
+    [cmdletbinding()]
+    param(
+        [Parameter(Mandatory)]
+        [ValidateNotNull()]
+        $VM
+    )
+    
+    # VM must be powered on to upgrade tools
+    if ($VM.PowerState -eq 'PoweredOn') {
+        Write-Verbose -Message 'Updating tools with [NoReboot]'
+        $VM | Update-Tools -NoReboot -Verbose:$false
+    } else {
+        Write-Error -Message 'VM must be powered on in order to update VM tools'
+    }
+}

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Invoke.ps1
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Invoke.ps1
@@ -46,6 +46,7 @@ switch ($type) {
                 vApp = $Options.options.vApp
                 VMFolder = $Options.options.VMFolder
                 Tags = $Options.options.Tags
+                UpdateTools = $Options.options.UpdateTools
                 InitialDatastore = $Options.options.InitialDatastore
                 Disks = ConvertTo-Json -InputObject $Options.options.disks -Depth 100
                 CustomizationSpec = $Options.options.CustomizationSpec
@@ -173,6 +174,7 @@ switch ($type) {
                     ResourcePool = $ResourceOptions.options.ResourcePool
                     vApp = $ResourceOptions.options.vApp
                     VMFolder = $ResourceOptions.options.VMFolder
+                    UpdateTools = $ResourceOptions.options.UpdateTools
                     Tags = ConvertTo-Json -InputObject $ResourceOptions.options.Tags
                     InitialDatastore = $ResourceOptions.options.InitialDatastore
                     Disks = ConvertTo-Json -InputObject $ResourceOptions.options.disks

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/POSHOrigin_vSphere_VM.schema.mof
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/POSHOrigin_vSphere_VM.schema.mof
@@ -15,6 +15,7 @@ class POSHOrigin_vSphere_VM : OMI_BaseResource
     [Write] String VMFolder;
     [Write] String CustomizationSpec;
     [Write] String Tags;
+    [Write] Boolean UpdateTools;
     [Write, EmbeddedInstance("MSFT_Credential")] String GuestCredentials;
     [Write, EmbeddedInstance("MSFT_Credential")] String IPAMCredentials;
     [Write, EmbeddedInstance("MSFT_Credential")] String DomainJoinCredentials;


### PR DESCRIPTION
This adds the ability to install/update VM tools.
### Example

``` powershell
resource 'vsphere:vm' 'myvm01' @{
    # other options omitted for brevity
    UpdateTools = $true
}
```

The default value is `$false` so if you do not wish to manage VM tools with this, there is no need to supply the option. If set to `$true` and VM tools are out of date/not installed, this will install/update with the `-NoReboot` switch set.
