### PR TITLE
Dev

### DIFF
--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Provisioners/Chef/Provision.ps1
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Provisioners/Chef/Provision.ps1
@@ -35,9 +35,9 @@ process {
                         $cert = $provOptions.cert
                         $certName = $cert.split('/') | Select-Object -Last 1
                         $runList = $provOptions.runList
-                        $automateUrl = $provOptions.automate_url
-                        $automateToken = $provOptions.automate_token
-                        $automateCert = $provOptions.automate_cert
+                        $automateUrl = $provOptions.automateUrl
+                        $automateToken = $provOptions.automateToken
+                        $automateCert = $provOptions.automateCert
                         if ($automateCert) {
                             $automateCertName = $automateCert.split('/') | Select-Object -Last 1
                         }
@@ -150,9 +150,9 @@ node_name               '$fqdnlower'
                 $automateCmd = {
                     $VerbosePreference = $Using:VerbosePreference
                     $chefOptions = $args[0]
-                    $automateUrl = $chefOptions.automate_url
-                    $automateToken = $chefOptions.automate_token
-                    $automateCert = $chefOptions.automate_cert
+                    $automateUrl = $chefOptions.automateUrl
+                    $automateToken = $chefOptions.automateToken
+                    $automateCert = $chefOptions.automateCert
                     $automateCertName = $automateCert.split('/') | Select-Object -Last 1
                     $testExists = Test-Path "C:\chef\trusted_certs\$automateCertName"
                     if (!($testExists)) {
@@ -203,7 +203,7 @@ node_name               '$fqdnlower'
                     ArgumentList = $chefOptions
                 }
 
-                if ($chefOptions.automate_url) {
+                if ($chefOptions.automateUrl) {
                     Invoke-Command @automateParams
                 }
 

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Provisioners/Chef/Provision.ps1
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Provisioners/Chef/Provision.ps1
@@ -35,6 +35,12 @@ process {
                         $cert = $provOptions.cert
                         $certName = $cert.split('/') | Select-Object -Last 1
                         $runList = $provOptions.runList
+                        $automateUrl = $provOptions.automate_url
+                        $automateToken = $provOptions.automate_token
+                        $automateCert = $provOptions.automate_cert
+                        if ($automateCert) {
+                            $automateCertName = $automateCert.split('/') | Select-Object -Last 1
+                        }
 
                         # Ensure Chef node name is always lowercase
                         $fqdnlower = $provOptions.nodeName.ToLower()
@@ -44,6 +50,9 @@ process {
                         Invoke-WebRequest -Uri $source -OutFile "c:\windows\temp\ChefClient\$sourceName"
                         Invoke-WebRequest -Uri $validatorKey -OutFile "c:\windows\temp\ChefClient\validator.pem"
                         Invoke-WebRequest -Uri $cert -OutFile "c:\windows\temp\ChefClient\$certName"
+                        if ($automateCert) {
+                            Invoke-WebRequest -Uri $automateCert -OutFile "C:\Windows\Temp\ChefClient\$automateCertName"
+                        }
 
                         # Install Chef MSI
                         $params = @{
@@ -73,7 +82,17 @@ validation_key           "c:\\chef\\validator.pem"
 chef_server_url          "$url"
 cookbook_path            ["C:\\chef_cookbooks"]
 "@
-
+                        if ($automateUrl) {
+                        $clientRB = @"
+chef_server_url             "$url"
+validation_client_name      "$validatorClientName"
+validation_key              "c:\\chef\\validator.pem"
+client_key                  "c:\\chef\\client.pem"
+node_name                   '$fqdnlower'
+data_collector.server_url   "$automateUrl"
+data_collector.token        "$automateToken"
+"@
+                        } else {
                         $clientRB = @"
 chef_server_url         "$url"
 validation_client_name  "$validatorClientName"
@@ -81,6 +100,7 @@ validation_key          "c:\\chef\\validator.pem"
 client_key              "c:\\chef\\client.pem"
 node_name               '$fqdnlower'
 "@
+                }
                         New-Item -Path "$HOME\.chef" -ItemType Directory -ErrorAction SilentlyContinue -Force
                         $knifeRB | Out-File -FilePath "$HOME\.chef\knife.rb" -Encoding ascii -Force
                         $clientRB | Out-File -FilePath 'c:\chef\client.rb' -Encoding ascii -Force
@@ -91,6 +111,9 @@ node_name               '$fqdnlower'
                         Copy-Item -Path "c:\windows\temp\ChefClient\$certName" -Destination 'c:\chef\trusted_certs' -Force
                         Copy-Item -Path "c:\windows\temp\ChefClient\$certName" -Destination "$HOME\.chef\trusted_certs" -Force
                         Copy-Item -Path "c:\windows\temp\ChefClient\validator.pem" -Destination 'c:\chef' -Force
+                        if ($automateCert) {
+                            Copy-Item -Path "c:\windows\temp\ChefClient\$automateCertName" -Destination 'c:\chef\trusted_certs' -Force
+                        }
 
                         # Start Chef as service
                         Start-Process -FilePath 'chef-service-manager' -ArgumentList '-a install' -NoNewWindow -Wait
@@ -122,6 +145,67 @@ node_name               '$fqdnlower'
 
             # Chef is already installed or was just installed
             if ($chefSvc -or $chefInstallResult) {
+            
+                # Check automate settings if any, and update if needed
+                $automateCmd = {
+                    $VerbosePreference = $Using:VerbosePreference
+                    $chefOptions = $args[0]
+                    $automateUrl = $chefOptions.automate_url
+                    $automateToken = $chefOptions.automate_token
+                    $automateCert = $chefOptions.automate_cert
+                    $automateCertName = $automateCert.split('/') | Select-Object -Last 1
+                    $testExists = Test-Path "C:\chef\trusted_certs\$automateCertName"
+                    if (!($testExists)) {
+                        Invoke-WebRequest -Uri "$automateCert" -OutFile "C:\chef\trusted_certs\$automateCertName" | Out-Null
+                    } else {
+                        Invoke-WebRequest -Uri "$automateCert" -OutFile "C:\chef\$automateCertName" | Out-Null
+                        $serverVersion = Get-Content "C:\chef\trusted_certs\$automateCertName"
+                        $currentVersion = Get-Content "C:\chef\$automateCertName"
+                        $compare = Compare-Object $serverVersion $currentVersion
+                        Start-Sleep -Seconds 1
+                        if ($compare) {
+                            Write-Verbose -Message "Updated chef automate cert"
+                            Move-Item -Path "C:\chef\$automateCertName" -Destination "C:\chef\trusted_certs\$automateCertName" -Force -Confirm:$false
+                        } else {
+                            Remove-Item -Path "C:\chef\$automateCertName" -Force -Confirm:$false
+                        }
+                    }
+                    $clientRB = Get-Content C:\chef\client.rb -ErrorAction SilentlyContinue | Out-String
+                    $autoUrl = "data_collector.server_url`t'$automateUrl'"
+                    $autoToken = "data_collector.token`t'$automateToken'"
+                    if ($clientRB -notlike "*$autoUrl*") {
+                        if ($clientRB -like "*data_collector.server_url*") {
+                            $clientRB = Get-Content C:\chef\client.rb -ErrorAction SilentlyContinue
+                            $clientRB | foreach-Object {$_ -replace "^.*data_collector.server_url.*$","data_collector.server_url`t'$automateUrl'"} | set-content C:\chef\client.rb
+                            Write-Verbose 'Updated chef client.rb for automate url'
+                        } else {
+                            Add-Content C:\chef\client.rb -Value "`r`ndata_collector.server_url`t'$automateUrl'"
+                            Write-Verbose 'Created entry in client.rb for automate url'
+                        }
+                    }
+
+                    $clientRB = Get-Content C:\chef\client.rb -ErrorAction SilentlyContinue | Out-String
+                    if ($clientRB -notlike "*$autoToken*") {
+                        if ($clientRB -like "*data_collector.token*") {
+                            $clientRB = Get-Content C:\chef\client.rb -ErrorAction SilentlyContinue
+                            $clientRB | foreach-Object {$_ -replace "^.*data_collector.token.*$","data_collector.token`t'$automateToken'"} | set-content C:\chef\client.rb
+                            Write-Verbose 'Updated chef client.rb for automate token'
+                        } else {
+                            Add-Content C:\chef\client.rb -Value "`r`ndata_collector.token`t'$automateToken'"
+                            Write-Verbose 'Created entry in client.rb for automate token'
+                        }
+                    }
+                }
+                $automateParams = @{
+                    ComputerName = $ip
+                    Credential = $Options.GuestCredentials
+                    ScriptBlock = $automateCmd
+                    ArgumentList = $chefOptions
+                }
+
+                if ($chefOptions.automate_url) {
+                    Invoke-Command @automateParams
+                }
 
                 # Get the node from Chef
                 $getParams = @{

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Provisioners/Chef/Test.ps1
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Provisioners/Chef/Test.ps1
@@ -120,9 +120,9 @@ process {
                     $automateCmd = {
                         $result = $true
                         $chefOptions = $args[0]
-                        $automateUrl = $chefOptions.automate_url
-                        $automateToken = $chefOptions.automate_token
-                        $automateCert = $chefOptions.automate_cert
+                        $automateUrl = $chefOptions.automateUrl
+                        $automateToken = $chefOptions.automateToken
+                        $automateCert = $chefOptions.automateCert
                         $automateCertName = $automateCert.split('/') | Select-Object -Last 1
                         $testExists = Test-Path "C:\chef\trusted_certs\$automateCertName"
                         if (!($testExists)) {
@@ -152,7 +152,7 @@ process {
                         ScriptBlock = $automateCmd
                         ArgumentList = $chefOptions
                     }
-                    if ($chefOptions.automate_url) {
+                    if ($chefOptions.automateUrl) {
                         $testAutomate = Invoke-Command @automateParams
                         if (!($testAutomate)) {
                             $chefNodeResult = $false

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Provisioners/Chef/Test.ps1
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Provisioners/Chef/Test.ps1
@@ -116,6 +116,51 @@ process {
                     } else {
                         Write-Verbose -Message "Chef attributes: MATCH"
                     }
+
+                    $automateCmd = {
+                        $result = $true
+                        $chefOptions = $args[0]
+                        $automateUrl = $chefOptions.automate_url
+                        $automateToken = $chefOptions.automate_token
+                        $automateCert = $chefOptions.automate_cert
+                        $automateCertName = $automateCert.split('/') | Select-Object -Last 1
+                        $testExists = Test-Path "C:\chef\trusted_certs\$automateCertName"
+                        if (!($testExists)) {
+                            $result = $false
+                        } else {
+                            Invoke-WebRequest -Uri "$automateCert" -OutFile "C:\chef\$automateCertName" | Out-Null
+                            $serverVersion = Get-Content "C:\chef\trusted_certs\$automateCertName"
+                            $currentVersion = Get-Content "C:\chef\$automateCertName"
+                            $compare = Compare-Object $serverVersion $currentVersion
+                            Start-Sleep -Seconds 1
+                            Remove-Item -Path "C:\chef\$automateCertName" -Force -Confirm:$false
+                            if ($compare) {
+                                $result = $false
+                            }
+                        }
+                        $clientRB = Get-Content C:\chef\client.rb -ErrorAction SilentlyContinue | Out-String
+                        $autoUrl = "data_collector.server_url`t'$automateUrl'"
+                        $autoToken = "data_collector.token`t'$automateToken'"
+                        if (($clientRB -notlike "*$autoUrl*") -or ($clientRB -notlike "*$autoToken*")) {
+                            $result = $false
+                        }
+                        return $result
+                    }
+                    $automateParams = @{
+                        ComputerName = $ip
+                        Credential = $Options.GuestCredentials
+                        ScriptBlock = $automateCmd
+                        ArgumentList = $chefOptions
+                    }
+                    if ($chefOptions.automate_url) {
+                        $testAutomate = Invoke-Command @automateParams
+                        if (!($testAutomate)) {
+                            $chefNodeResult = $false
+                            Write-Verbose -Message 'Chef automate settings: MISMATCH'
+                        } else {
+                            Write-Verbose -Message 'Chef automate settings: MATCH'
+                        }
+                    }
                 } else {
                     $chefNodeResult = $false
                     Write-Verbose -Message 'Chef client: installed but node could not be found on Chef server'

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Provisioners/Powershell/Deprovision.ps1
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Provisioners/Powershell/Deprovision.ps1
@@ -14,7 +14,7 @@ process {
     if (($scriptPath.StartsWith('http://')) -or ($scriptPath.StartsWith('https://'))) {
         $filename = $scriptPath.Substring($scriptPath.LastIndexOf('/') + 1)
         $output = "$($ENV:Temp)\$filename"
-        Invoke-WebRequest -Uri $scriptPath -OutFile $output
+        Invoke-WebRequest -Uri $scriptPath -OutFile $output | Out-Null
         & $output -Options $Options -Mode 'Deprovision'
     } elseif (Test-Path -Path $scriptPath) {
         & $scriptPath -Options $Options -Mode 'Deprovision'

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Provisioners/Powershell/Provision.ps1
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Provisioners/Powershell/Provision.ps1
@@ -14,7 +14,7 @@ process {
     if (($scriptPath.StartsWith('http://')) -or ($scriptPath.StartsWith('https://'))) {
         $filename = $scriptPath.Substring($scriptPath.LastIndexOf('/') + 1)
         $output = "$($ENV:Temp)\$filename"
-        Invoke-WebRequest -Uri $scriptPath -OutFile $output
+        Invoke-WebRequest -Uri $scriptPath -OutFile $output | Out-Null
         & $output -Options $Options -Mode 'Provision'
     } elseif (Test-Path -Path $scriptPath) {
         & $scriptPath -Options $Options -Mode 'Provision'

--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Provisioners/Powershell/Test.ps1
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Provisioners/Powershell/Test.ps1
@@ -14,7 +14,7 @@ process {
     if (($scriptPath.StartsWith('http://')) -or ($scriptPath.StartsWith('https://'))) {
         $filename = $scriptPath.Substring($scriptPath.LastIndexOf('/') + 1)
         $output = "$($ENV:Temp)\$filename"
-        Invoke-WebRequest -Uri $scriptPath -OutFile $output
+        Invoke-WebRequest -Uri $scriptPath -OutFile $output | Out-Null
         $result = & $output -Options $Options -Mode 'Test'
         return $result
     } elseif (Test-Path -Path $scriptPath) {

--- a/README.md
+++ b/README.md
@@ -191,16 +191,19 @@ Provisioners = @(
 
 Bootstraps the Chef client on the VM after provisioning. Also registers the Chef client with the specific organization and applies the specified run list, attributes, and environment.
 
-| Name         | Type        | Required | Description
-| :------------|:------------|:---------|:-----------|
-| NodeName     | string      | True     | Name to assign the node in Chef
-| Url          | string      | True     | URL for the Chef organization
-| Source       | string      | True     | URL to the Chef client MSI file to install
-| ValidatorKey | string      | True     | URL to the Chef validator .pem file that has rights to joins nodes to the organization
-| Cert         | string      | True     | URL to the certificate to add to Chef's 'trusted_certs' folder
-| RunList      | hashtable[] | False    | Set of recipes or roles to assign to the node
-| Environment  | string      | False    | Chef environment to assign the node to
-| Attributes   | hashtable   | False    | Hashtable of attributes to assign to the node
+| Name          | Type        | Required | Description
+| :-------------|:------------|:---------|:-----------|
+| NodeName      | string      | True     | Name to assign the node in Chef
+| Url           | string      | True     | URL for the Chef organization
+| Source        | string      | True     | URL to the Chef client MSI file to install
+| ValidatorKey  | string      | True     | URL to the Chef validator .pem file that has rights to joins nodes to the organization
+| Cert          | string      | True     | URL to the certificate to add to Chef's 'trusted_certs' folder
+| RunList       | hashtable[] | False    | Set of recipes or roles to assign to the node
+| Environment   | string      | False    | Chef environment to assign the node to
+| Attributes    | hashtable   | False    | Hashtable of attributes to assign to the node
+| Automate_url  | string      | False    | URL for your Chef Automate server
+| Automate_token| string      | False    | Token for authenticating with Chef Automate
+| Automate_cert | string      | False    | URL to the Chef Automate cert to Chefs trusted certs folder
 
 ```powerShell
 Provisioners = @(
@@ -217,6 +220,9 @@ Provisioners = @(
              @{ recipe = 'myapp::default' }
           )
           environment = 'prod'
+          automate_url = 'https://chefautomatesvr.mydomain.com/data-collector/v0/'
+          automate_token = '<CHEF_AUTOMATE_TOKEN>'
+          automate_cert = '<URL to issuing CA .crt file for chef automate>'
           attributes = @{
              myapp = @{
                 prop1 = 42

--- a/README.md
+++ b/README.md
@@ -201,9 +201,9 @@ Bootstraps the Chef client on the VM after provisioning. Also registers the Chef
 | RunList       | hashtable[] | False    | Set of recipes or roles to assign to the node
 | Environment   | string      | False    | Chef environment to assign the node to
 | Attributes    | hashtable   | False    | Hashtable of attributes to assign to the node
-| Automate_url  | string      | False    | URL for your Chef Automate server
-| Automate_token| string      | False    | Token for authenticating with Chef Automate
-| Automate_cert | string      | False    | URL to the Chef Automate cert to Chefs trusted certs folder
+| AutomateUrl   | string      | False    | URL for your Chef Automate server
+| AutomateToken | string      | False    | Token for authenticating with Chef Automate
+| AutomateCert  | string      | False    | URL to the Chef Automate cert to Chefs trusted certs folder
 
 ```powerShell
 Provisioners = @(
@@ -220,9 +220,9 @@ Provisioners = @(
              @{ recipe = 'myapp::default' }
           )
           environment = 'prod'
-          automate_url = 'https://chefautomatesvr.mydomain.com/data-collector/v0/'
-          automate_token = '<CHEF_AUTOMATE_TOKEN>'
-          automate_cert = '<URL to issuing CA .crt file for chef automate>'
+          automateUrl = 'https://chefautomatesvr.mydomain.com/data-collector/v0/'
+          automateToken = '<CHEF_AUTOMATE_TOKEN>'
+          automateCert = '<URL to issuing CA .crt file for chef automate>'
           attributes = @{
              myapp = @{
                 prop1 = 42


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

Added the ability to define chef automate url, token, and cert in the chef provisioner options
i.e.

```
@{
      name = 'chef'
            options = @{
                nodeName = 'test'
                source = 'http://abc.com/mychef.msi'
                url = 'https://mychefserver.com/organizations/org'
                cert = 'http://abc.com/cert.crt
                clientKey = 'http://abc.com/clientkey.pem'
                validatorKey = 'http://abc.com/validator.pem'
                environment = 'my_env'
                automate_url = 'https://mychefautomateserver.com/data-collector/v0/'
                automate_token = 'CHEF_AUTOMATE_TOKEN_GOES_HERE'
                automate_cert = 'http://abc.com/cert.crt'
                runList = @(
                    @{ role = 'my_role'}
                )
}
```
## Related Issue
#31
## Motivation and Context

Adds the ability to setup servers with chef automate settings during provision
## How Has This Been Tested?
- Tested with no attributes to verify tests and provision were skipped
- Tested with new attributes, with current client.rb NOT having the new attributes
- Tested with new attributes, with current client.rb having incorrect new attributes
- Tested with new attributes, with current client.rb having the correct new attributes
- Tested the cert to verify it was adding or replacing if it was different

ALL tests were done on 2012r2
## Screenshots (if appropriate):
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
