### PR TITLE
Add OsCustomizationSpec param to New-VM

### DIFF
--- a/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_CreateVM.ps1
+++ b/POSHOrigin_vSphere/DSCResources/POSHOrigin_vSphere_VM/Helpers/_CreateVM.ps1
@@ -196,6 +196,7 @@ function _CreateVM {
                 Datastore = $datastore
                 #DiskStorageFormat = $diskFormat
                 ResourcePool = $viContainer
+                OSCustomizationSpec = $custSpec
                 RunAsync = $true
                 Verbose = $false
                 Confirm = $false


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
fixes #39 
## Description
CustomizationSpec is a mandatory parameter but was never used when creating VM. 
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X ] All new and existing tests passed.
